### PR TITLE
fix array.sort bug

### DIFF
--- a/src/BuildList.js
+++ b/src/BuildList.js
@@ -10,7 +10,7 @@ const BuildLink = ({id, text, children}) => {
 
 const BuildList = (listItems) => {
   const list = listItems
-    .sort((a, b) => a.order > b.order)
+    .sort((a, b) => a.order - b.order)
     .map(li => BuildLink(li))
 
   return ( list.length > 0 )


### PR DESCRIPTION
Okay, so this is an [odd bug in node](https://github.com/nodejs/node-v0.x-archive/issues/5754), but when I get a Table of Contents with exactly 11 headers, they come back in the wrong order, with the 6th one first.

Here's a simple reproducible example

```js
$ node
> var objects = [ { o: 0 }, {o: 1}, {o: 2}, {o: 3}, {o: 5}, { o: 6 }, {o: 7}, {o: 8}, {o: 9}, {o: 10}, {o: 11} ];
> objects.sort((a,b) => a.o > b.o ).map(x => x.o);
> // [ 6, 0, 1, 2, 3, 5, 7, 8, 9, 10, 11 ]
> objects.sort((a,b) => a.o - b.o ).map(x => x.o);
> // [ 0, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11 ]
```

<img src="https://user-images.githubusercontent.com/4307307/62016665-67177980-b181-11e9-9fe2-58629271148e.png" width="435px"/>

According to the docs on MDN, the `compareFunction` for `Array.sort()` should return an `integer` of `-1`, `0`, or `1`.  Although returning false works in most other browsers and javascript engines I've tried, it might be better to return the expected values.

In the docs on MDN, they suggest [using a `-` sign for comparing numbers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort):

>To compare numbers instead of strings, the compare function can simply subtract b from a. 
>
>```js
>function compareNumbers(a, b) {
>  return a - b;
>}
>```

So a super minor edit, but one that hits this odd edge case.