### PR TITLE
feat(options): allow default options when `addPlugin`

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,7 +1,19 @@
-const buildTOC = require('./src/BuildTOC')
+const buildTOC = require('./src/BuildTOC');
 
-module.exports = function(eleventyConfig, pluginNamespace) {
-  eleventyConfig.namespace(pluginNamespace, () => {
-    eleventyConfig.addFilter('toc', (content, opts) => buildTOC(content, opts))
-  })
-}
+module.exports = (function() {
+  let _opts = {}
+  function TOC(eleventyConfig, pluginNamespace) {
+    eleventyConfig.namespace(pluginNamespace, () => {
+      eleventyConfig.addFilter('toc', (content, opts) => {
+        return buildTOC(content, {..._opts, ...opts})
+      });
+    });
+  }
+
+  TOC.opts = function(opts) {
+    _opts = opts
+    return this
+  }
+
+  return TOC
+})()

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,8 +1,11 @@
 const buildTOC = require('./src/BuildTOC')
 const parseOptions = require('./src/ParseOptions')
 
-module.exports = (eleventyConfig, globalOpts = {}) => {
-  eleventyConfig.addFilter('toc', (content, localOpts) => {
-    return buildTOC(content, parseOptions(localOpts, globalOpts))
+module.exports = (eleventyConfig, globalOpts) => {
+  globalOpts = globalOpts || {}
+  eleventyConfig.namespace(globalOpts, () => {
+    eleventyConfig.addFilter('toc', (content, localOpts) => {
+      return buildTOC(content, parseOptions(localOpts, globalOpts))
+    })
   })
 }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,19 +1,8 @@
 const buildTOC = require('./src/BuildTOC')
+const parseOptions = require('./src/ParseOptions')
 
-module.exports = (function() {
-  let _opts = {}
-  function TOC(eleventyConfig, pluginNamespace) {
-    eleventyConfig.namespace(pluginNamespace, () => {
-      eleventyConfig.addFilter('toc', (content, opts) => {
-        return buildTOC(content, {..._opts, ...opts})
-      });
-    });
-  }
-
-  TOC.opts = function(opts) {
-    _opts = opts
-    return this
-  }
-
-  return TOC
-})()
+module.exports = (eleventyConfig, globalOpts = {}) => {
+  eleventyConfig.addFilter('toc', (content, localOpts) => {
+    return buildTOC(content, parseOptions(localOpts, globalOpts))
+  })
+}

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,4 @@
-const buildTOC = require('./src/BuildTOC');
+const buildTOC = require('./src/BuildTOC')
 
 module.exports = (function() {
   let _opts = {}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This Eleventy plugin will generate a TOC from page content using an Eleventy fil
 {
   tags: ['h2', 'h3', 'h4'], // which heading tags are selected headings must each have an ID attribute
   wrapper: 'nav',           // element to put around the root `ol`/`ul`
-  wrapperClass: 'toc'       // class for the element around the root `ol`/`ul`
-  ul: false                 // if to use `ul` instead of `ol`
+  wrapperClass: 'toc',      // class for the element around the root `ol`/`ul`
+  ul: false,                // if to use `ul` instead of `ol`
+  flat: false,              // if subheadings should appear as child of parent or as a sibling
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ module.exports = function (eleventyConfig) {
 }
 ```
 
+#### 3.1 You can override the default plugin options
+
+```js
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(pluginTOC, {
+    tags: ['h2', 'h3'],
+    wrapper: 'div'
+  })
+}
+```
+
 ### 4. Use the filter in your template
 
 ```liquid
@@ -70,7 +81,6 @@ module.exports = function (eleventyConfig) {
 If you're using Nunjucks, include the `safe` filter:
 
 ```njk
-
 <article>
   {{ content | safe }}
 </article>
@@ -102,5 +112,4 @@ Pass a stringified JSON object (must be `JSON.parse()`-able) as an option for in
 
 ## Roadmap
 
-- [ ] I'd like to expose the default options to overriding in an Eleventy config file
 - [ ] Some tests would be nice

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This Eleventy plugin will generate a TOC from page content using an Eleventy fil
 
 ```js
 {
-  tags: ['h2', 'h3', 'h4'], // which heading tags are selected
-                            // headings must each have an ID attribute
-  wrapper: 'nav',           // element to put around the root `ol`
-  wrapperClass: 'toc'       // class for the element around the root `ol`
+  tags: ['h2', 'h3', 'h4'], // which heading tags are selected headings must each have an ID attribute
+  wrapper: 'nav',           // element to put around the root `ol`/`ul`
+  wrapperClass: 'toc'       // class for the element around the root `ol`/`ul`
+  ul: false                 // if to use `ul` instead of `ol`
 }
 ```
 
@@ -96,10 +96,10 @@ Pass a stringified JSON object (must be `JSON.parse()`-able) as an option for in
 ```liquid
 <aside>
   {{ content | toc: '{"tags":["h2","h3"],"wrapper":"div","wrapperClass":"content-tableau"}' }}
-</article>
+</aside>
 ```
 
 ## Roadmap
 
-* [ ] I'd like to expose the default options to overriding in an Eleventy config file
-* [ ] Some tests would be nice
+- [ ] I'd like to expose the default options to overriding in an Eleventy config file
+- [ ] Some tests would be nice

--- a/src/BuildList.js
+++ b/src/BuildList.js
@@ -7,21 +7,29 @@ const _escText = text => {
     .replace(/"/g, '&quot;');
 }
 
-const _buildLink = ({id, text, children}) => {
-  const nestedList = children.length > 0
-    ? BuildList(children)
-    : ''
+const _buildLink = ({id, text, children}, flat) => {
+  let nestedList = ''
 
-  return ( id && text )
-    ? `<li><a href="#${id}">${_escText(text)}</a>${nestedList}</li>`
-    : ''
+  if (children.length > 0 && flat) {
+    nestedList = children.map(c => _buildLink(c, flat));
+  } else if (children.length > 0) {
+    nestedList = BuildList(children)
+  }
+
+  if (id && text && flat) {
+    return `<li><a href="#${id}">${_escText(text)}</a></li>${(nestedList || []).join('')}`
+  } else if (id && text) {
+    return `<li><a href="#${id}">${_escText(text)}</a>${nestedList}</li>`
+  } else {
+    return nestedList;
+  }
 }
 
-const BuildList = (listItems, ul) => {
+const BuildList = (listItems, ul, flat) => {
   const listType = ul ? 'ul' : 'ol'
   const list = listItems
     .sort((a, b) => a.order - b.order)
-    .map(li => _buildLink(li))
+    .map(li => _buildLink(li, flat))
 
   return ( list.length > 0 )
     ? `<${listType}>${list.join('')}</${listType}>`

--- a/src/BuildList.js
+++ b/src/BuildList.js
@@ -17,13 +17,14 @@ const _buildLink = ({id, text, children}) => {
     : ''
 }
 
-const BuildList = (listItems) => {
+const BuildList = (listItems, ul) => {
+  const listType = ul ? 'ul' : 'ol'
   const list = listItems
     .sort((a, b) => a.order - b.order)
     .map(li => _buildLink(li))
 
   return ( list.length > 0 )
-    ? `<ol>${list.join('')}</ol>`
+    ? `<${listType}>${list.join('')}</${listType}>`
     : ''
 }
 

--- a/src/BuildList.js
+++ b/src/BuildList.js
@@ -4,24 +4,26 @@ const _escText = text => {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
 }
 
 const _buildLink = ({id, text, children}, flat) => {
   let nestedList = ''
 
   if (children.length > 0 && flat) {
-    nestedList = children.map(c => _buildLink(c, flat));
+    nestedList = children.map(c => _buildLink(c, flat))
   } else if (children.length > 0) {
     nestedList = BuildList(children)
   }
 
   if (id && text && flat) {
-    return `<li><a href="#${id}">${_escText(text)}</a></li>${(nestedList || []).join('')}`
+    return `<li><a href="#${id}">${_escText(text)}</a></li>${(
+      nestedList || []
+    ).join('')}`
   } else if (id && text) {
     return `<li><a href="#${id}">${_escText(text)}</a>${nestedList}</li>`
   } else {
-    return nestedList;
+    return nestedList
   }
 }
 
@@ -31,9 +33,7 @@ const BuildList = (listItems, ul, flat) => {
     .sort((a, b) => a.order - b.order)
     .map(li => _buildLink(li, flat))
 
-  return ( list.length > 0 )
-    ? `<${listType}>${list.join('')}</${listType}>`
-    : ''
+  return list.length > 0 ? `<${listType}>${list.join('')}</${listType}>` : ''
 }
 
 module.exports = BuildList

--- a/src/BuildTOC.js
+++ b/src/BuildTOC.js
@@ -1,5 +1,4 @@
 const cheerio = require('cheerio')
-const debug = require("debug")("plugin-toc")
 
 const ParseOptions = require('./ParseOptions')
 const NestHeadings = require('./NestHeadings')
@@ -10,18 +9,19 @@ const defaults = {
   wrapper: 'nav',
   wrapperClass: 'toc',
   ul: false,
-  flat: false
+  flat: false,
 }
 
 const BuildTOC = (text, opts) => {
-  const { tags, wrapper, wrapperClass, ul, flat } = ParseOptions(opts, defaults)
+  const {tags, wrapper, wrapperClass, ul, flat} = ParseOptions(opts, defaults)
 
   const $ = cheerio.load(text)
 
   const headings = NestHeadings(tags, $)
 
-  return (headings.length > 0)
-    ? `<${wrapper} class="${wrapperClass}">${BuildList(headings, ul, flat)}</${wrapper}>`
+  return headings.length > 0
+    ? `<${wrapper} class="${wrapperClass}">
+        ${BuildList(headings, ul, flat)}</${wrapper}>`
     : undefined
 }
 

--- a/src/BuildTOC.js
+++ b/src/BuildTOC.js
@@ -9,18 +9,19 @@ const defaults = {
   tags: ['h2', 'h3', 'h4'],
   wrapper: 'nav',
   wrapperClass: 'toc',
-  ul: false
+  ul: false,
+  flat: false
 }
 
 const BuildTOC = (text, opts) => {
-  const { tags, wrapper, wrapperClass, ul } = ParseOptions(opts, defaults)
+  const { tags, wrapper, wrapperClass, ul, flat } = ParseOptions(opts, defaults)
 
   const $ = cheerio.load(text)
 
   const headings = NestHeadings(tags, $)
 
   return (headings.length > 0)
-    ? `<${wrapper} class="${wrapperClass}">${BuildList(headings)}</${wrapper}>`
+    ? `<${wrapper} class="${wrapperClass}">${BuildList(headings, ul, flat)}</${wrapper}>`
     : undefined
 }
 

--- a/src/BuildTOC.js
+++ b/src/BuildTOC.js
@@ -8,11 +8,12 @@ const BuildList = require('./BuildList')
 const defaults = {
   tags: ['h2', 'h3', 'h4'],
   wrapper: 'nav',
-  wrapperClass: 'toc'
+  wrapperClass: 'toc',
+  ul: false
 }
 
 const BuildTOC = (text, opts) => {
-  const { tags, wrapper, wrapperClass } = ParseOptions(opts, defaults)
+  const { tags, wrapper, wrapperClass, ul } = ParseOptions(opts, defaults)
 
   const $ = cheerio.load(text)
 

--- a/src/NestHeadings.js
+++ b/src/NestHeadings.js
@@ -1,30 +1,29 @@
 const SimplifyResults = require('./SimplifyResults')
 
 const NestHeadings = (tags, $) => {
-  let temp = {}
+  const temp = {}
 
-  tags
-    .forEach((t, i) => {
-      temp[t] = SimplifyResults(t, tags, $)
-    })
+  tags.forEach(t => {
+    temp[t] = SimplifyResults(t, tags, $)
+  })
 
-  let headings = []
+  const headings = []
 
   Object.keys(temp)
     .reverse()
     .filter(t => temp[t].length > 0)
-    .map((k) => {
+    .map(k => {
       const index = tags.indexOf(k)
 
       temp[k].map(h => {
         let parent = headings
 
-        if ( index > 0 ) {
-          let potentialParent = temp[tags[index - 1]].find(p => {
-            return p.id == h.parent
+        if (index > 0) {
+          const potentialParent = temp[tags[index - 1]].find(p => {
+            return p.id === h.parent
           })
 
-          if ( potentialParent && 'children' in potentialParent ) {
+          if (potentialParent && 'children' in potentialParent) {
             parent = potentialParent.children
           }
         }

--- a/src/ParseOptions.js
+++ b/src/ParseOptions.js
@@ -1,7 +1,11 @@
 const ParseOptions = (userOptions, defaultOptions) => {
   let safeOptions = {}
   try {
-    safeOptions = JSON.parse(userOptions);
+    if (typeof userOptions === 'string') {
+      safeOptions = JSON.parse(userOptions)
+    } else if (typeof userOptions === 'object') {
+      safeOptions = userOptions
+    }
   } catch (e) {
     safeOptions = {}
   }

--- a/src/ParseOptions.js
+++ b/src/ParseOptions.js
@@ -1,16 +1,20 @@
 const ParseOptions = (userOptions, defaultOptions) => {
-  let safeOptions = {}
-  try {
-    if (typeof userOptions === 'string') {
-      safeOptions = JSON.parse(userOptions)
-    } else if (typeof userOptions === 'object') {
-      safeOptions = userOptions
-    }
-  } catch (e) {
-    safeOptions = {}
+  let safeDefaultOptions = {}
+  let safeUserOptions = {}
+
+  if (defaultOptions && defaultOptions.constructor === {}.constructor) {
+    safeDefaultOptions = defaultOptions
   }
 
-  return Object.assign({}, defaultOptions, safeOptions)
+  if (userOptions && typeof userOptions === 'string') {
+    try {
+      safeUserOptions = JSON.parse(userOptions)
+    } catch (e) {} // eslint-disable-line
+  } else if (userOptions && userOptions.constructor === {}.constructor) {
+    safeUserOptions = userOptions
+  }
+
+  return Object.assign({}, safeDefaultOptions, safeUserOptions)
 }
 
 module.exports = ParseOptions

--- a/src/SimplifyResults.js
+++ b/src/SimplifyResults.js
@@ -1,14 +1,16 @@
 const SimplifyResults = (tag, tags, $) => {
-  let results = []
+  const results = []
 
   $(`${tag}[id]`).each((i, el) => {
     const tag = el.name
     const id = $(el).attr('id')
     const text = $(el).text().replace(' #', '')
     const hierarchy = tags.indexOf(tag)
-    const parent = ( hierarchy > 0 )
-      ? $(el).prevAll(tags[hierarchy - 1]).attr('id')
-      : false
+    const parent =
+      hierarchy > 0 &&
+      $(el)
+        .prevAll(tags[hierarchy - 1])
+        .attr('id')
 
     results.push({
       order: i,
@@ -16,7 +18,7 @@ const SimplifyResults = (tag, tags, $) => {
       id,
       text,
       parent,
-      children: []
+      children: [],
     })
   })
 


### PR DESCRIPTION
Instead of needing to add options to the templates as a string, this would allow default options to be set when you add the plugin to the 11ty config. Also I added the option to use `ul` instead of `ol`.