### PR TITLE
feat: Added extractText config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Pass a stringified JSON object (must be `JSON.parse()`-able) as an option for in
 | wrapperLabel | `undefined` | string | `aria-label` on element wrapping toc lists |
 | ul | `false` | boolean | lists are `ul` if true, `ol` if `false` |
 | flat | `false` | boolean | use flat list if `true`; use nested lists if false |
+| extractText | `undefined` | function | A function that can be used to extract the text from the heading (if custom processing is needed). It receives the cheerio header element as argument |
 
 ## Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "eleventy-plugin-toc",
       "version": "1.1.5",
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,9 +1079,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1183,9 +1183,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/prelude-ls": {
@@ -2329,9 +2329,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -2415,9 +2415,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "prelude-ls": {

--- a/src/BuildTOC.js
+++ b/src/BuildTOC.js
@@ -11,6 +11,7 @@ const defaults = {
   wrapperLabel: undefined,
   ul: false,
   flat: false,
+  extractText: undefined,
 }
 
 const BuildTOC = (text, opts) => {
@@ -21,7 +22,7 @@ const BuildTOC = (text, opts) => {
 
   const $ = cheerio.load(text)
 
-  const headings = NestHeadings(tags, $)
+  const headings = NestHeadings(tags, opts.extractText, $)
 
   if (headings.length === 0) {
     return undefined

--- a/src/NestHeadings.js
+++ b/src/NestHeadings.js
@@ -1,10 +1,10 @@
 const SimplifyResults = require('./SimplifyResults')
 
-const NestHeadings = (tags, $) => {
+const NestHeadings = (tags, extractText, $) => {
   const temp = {}
 
   tags.forEach(t => {
-    temp[t] = SimplifyResults(t, tags, $)
+    temp[t] = SimplifyResults(t, tags, extractText, $)
   })
 
   const headings = []

--- a/src/SimplifyResults.js
+++ b/src/SimplifyResults.js
@@ -1,10 +1,14 @@
-const SimplifyResults = (tag, tags, $) => {
+const SimplifyResults = (tag, tags, extractText, $) => {
   const results = []
 
   $(`${tag}[id]`).each((i, el) => {
     const tag = el.name
     const id = $(el).attr('id')
-    const text = $(el).text().replace(' #', '')
+    let baseText = $(el).text()
+    if (typeof extractText === 'function') {
+      baseText = extractText($(el))
+    }
+    let text = baseText.replace(' #', '')
     const hierarchy = tags.indexOf(tag)
     const parent =
       hierarchy > 0 &&


### PR DESCRIPTION
This PR suggests a new option that allows users to customize how the text gets extrapolated from every heading entry.

## Example use case

I have a markdown plugin that changes all my entries adding a **direct link** placeholder that can be used to easily link to headers.

For example, a simple `h2` like the following:

```html
<h2>My Study notes</h2>
```

Becomes:

```html
<h2 id="my-study-notes" tabindex="-1"><a class="direct-link" href="#my-study-notes">
  <span class="sr-only">Jump to heading</span>
  <span aria-hidden="true">#</span>
</a> My Study notes</h2>
```

Because of this plugin when I use `eleventy-plugin-toc` I will end up with an entry in my TOC that would look like this:

```plain
Jump to heading My Study notes
```

Rather than just _My Study notes_.


## Example usage of the proposed feature

With this new feature it is possible to customize how the text is extracted, so to fix the problem described in the previous section I could do the following:

```js
// eleventy config
const pluginTOC = require('eleventy-plugin-toc')

// ...
module.exports = function (eleventyConfig) {
  // ...
  eleventyConfig.addPlugin(pluginTOC, {
    extractText: function(el) {
      return el.text().replace('Jump to heading', '').replace('#', '').trim()
    }
  })
  // ...
}
```


---

PS: as a bonus, this PR removes some vulnerabilities by running `npm audit fix`